### PR TITLE
Adapter interface generator branch

### DIFF
--- a/spacebattle/AdapterBuilder.cs
+++ b/spacebattle/AdapterBuilder.cs
@@ -1,4 +1,4 @@
-namespace spacebattle;
+﻿namespace spacebattle;
 
 using System.Reflection;
 using System.Text.RegularExpressions;

--- a/spacebattle/AdapterBuilder.cs
+++ b/spacebattle/AdapterBuilder.cs
@@ -1,0 +1,77 @@
+namespace spacebattle;
+
+using System.Reflection;
+using System.Text.RegularExpressions;
+
+public class AdapterBuilder
+{
+    private readonly string adaptername;
+    private readonly string adaptertypename;
+    private readonly string targettypename;
+    private string? properties;
+
+    public AdapterBuilder(Type adaptertype, Type targettype)
+    {
+        adaptername = adaptertype.Name.Substring(1);
+        adaptertypename = adaptertype.Name;
+        targettypename = FormatGenericType(targettype);
+    }
+
+    public void CreateProperty(PropertyInfo p)
+    {
+        string get = string.Empty, set = string.Empty;
+
+        var propertyname = FormatGenericType(p.PropertyType);
+
+        if (p.CanRead)
+        {
+            get = $@"   get {{ return IoC.Resolve<{propertyname}>(""Game.{p.Name}.Get"", target); }}";
+        }
+
+        if (p.CanWrite)
+        {
+            set = $@"   set {{ IoC.Resolve<_ICommand.ICommand>(""Game.{p.Name}.Set"", target, value).Execute(); }}";
+        }
+
+        properties +=
+        $@"
+        public {propertyname} {p.Name} {{
+            {get}
+            {set}
+        }}
+        ";
+    }
+
+    private static string FormatGenericType(Type type)
+    {
+        var typeName = type.Name;
+
+        if (type.IsGenericType)
+        {
+            typeName = typeName.Substring(0, typeName.IndexOf('`'));
+
+            var typeArgs = type.GetGenericArguments();
+            var typeArgNames = new string[typeArgs.Length];
+            for (var i = 0; i < typeArgs.Length; i++)
+            {
+                typeArgNames[i] = FormatGenericType(typeArgs[i]);
+            }
+
+            typeName = $"{typeName}<{string.Join(", ", typeArgNames)}>";
+        }
+
+        return typeName;
+    }
+
+    public string Build()
+    {
+        var result = @$"class {adaptername}Adapter : {adaptertypename} {{
+        {targettypename} target;
+        public {adaptername}Adapter({targettypename} target) => this.target = target; 
+        {properties}
+    }}";
+
+        result = Regex.Replace(result, @"^\s+$[\r\n]*", string.Empty, RegexOptions.Multiline);
+        return result;
+    }
+}

--- a/spacebattle/AdapterCodeGeneratorStrategy.cs
+++ b/spacebattle/AdapterCodeGeneratorStrategy.cs
@@ -5,20 +5,20 @@ using SpaceBattle;
 
 public class AdapterCodeGeneratorStrategy : IStrategy
 {
-    public object Strategy(params object[] args)
+    public object Strategy(params object[] paramsArray)
     {
-        var adapterType = (Type)args[0];
-        var targetType = (Type)args[1];
+        var sourceType = (Type)paramsArray[0];
+        var destinationType = (Type)paramsArray[1];
 
-        var builder = new AdapterBuilder(adapterType, targetType);
+        var adapterConstructor = new AdapterBuilder(sourceType, destinationType);
 
-        var properties = adapterType.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+        var sourceProperties = sourceType.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
 
-        foreach (var p in properties)
+        foreach (var propertyItem in sourceProperties)
         {
-            builder.CreateProperty(p);
+            adapterConstructor.CreateProperty(propertyItem);
         }
 
-        return builder.Build();
+        return adapterConstructor.Build();
     }
 }

--- a/spacebattle/AdapterCodeGeneratorStrategy.cs
+++ b/spacebattle/AdapterCodeGeneratorStrategy.cs
@@ -1,0 +1,24 @@
+﻿namespace spacebattle;
+
+using System.Reflection;
+using SpaceBattle;
+
+public class AdapterCodeGeneratorStrategy : IStrategy
+{
+    public object Strategy(params object[] args)
+    {
+        var adapterType = (Type)args[0];
+        var targetType = (Type)args[1];
+
+        var builder = new AdapterBuilder(adapterType, targetType);
+
+        var properties = adapterType.GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic);
+
+        foreach (var p in properties)
+        {
+            builder.CreateProperty(p);
+        }
+
+        return builder.Build();
+    }
+}

--- a/spacebattle/DynamicAdapterBuilder.cs
+++ b/spacebattle/DynamicAdapterBuilder.cs
@@ -10,30 +10,30 @@ public class DynamicAdapterCompiler
 {
     public static Assembly CompileCode(string sourceCode)
     {
-        var assemblyName = Path.GetRandomFileName();
-        var syntaxTree = CSharpSyntaxTree.ParseText(sourceCode);
+        var assemblyId = Path.GetRandomFileName();
+        var codeStructure = CSharpSyntaxTree.ParseText(sourceCode);
 
-        var references = new List<MetadataReference>
+        var assemblyReferences = new List<MetadataReference>
         {
             MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
             MetadataReference.CreateFromFile(typeof(IoC).Assembly.Location)
         };
 
-        var compilation = CSharpCompilation.Create(
-            assemblyName,
-            new[] { syntaxTree },
-            references,
+        var codeCompilation = CSharpCompilation.Create(
+            assemblyId,
+            new[] { codeStructure },
+            assemblyReferences,
             new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
 
-        using var ms = new MemoryStream();
-        var result = compilation.Emit(ms);
+        using var stream = new MemoryStream();
+        var compilationResult = codeCompilation.Emit(stream);
 
-        if (!result.Success)
+        if (!compilationResult.Success)
         {
             throw new InvalidOperationException("Compilation failed");
         }
 
-        ms.Seek(0, SeekOrigin.Begin);
-        return Assembly.Load(ms.ToArray());
+        stream.Seek(0, SeekOrigin.Begin);
+        return Assembly.Load(stream.ToArray());
     }
 }

--- a/spacebattle/DynamicAdapterBuilder.cs
+++ b/spacebattle/DynamicAdapterBuilder.cs
@@ -1,0 +1,40 @@
+﻿namespace SpaceBattle;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Reflection;
+using Hwdtech;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+
+public class DynamicAdapterCompiler
+{
+    public static Assembly CompileCode(string sourceCode)
+    {
+        var assemblyName = Path.GetRandomFileName();
+        var syntaxTree = CSharpSyntaxTree.ParseText(sourceCode);
+
+        var references = new List<MetadataReference>
+        {
+            MetadataReference.CreateFromFile(typeof(object).Assembly.Location),
+            MetadataReference.CreateFromFile(typeof(IoC).Assembly.Location)
+        };
+
+        var compilation = CSharpCompilation.Create(
+            assemblyName,
+            new[] { syntaxTree },
+            references,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        using var ms = new MemoryStream();
+        var result = compilation.Emit(ms);
+
+        if (!result.Success)
+        {
+            throw new InvalidOperationException("Compilation failed");
+        }
+
+        ms.Seek(0, SeekOrigin.Begin);
+        return Assembly.Load(ms.ToArray());
+    }
+}

--- a/spacebattle/DynamicAdapterBuilder.cs
+++ b/spacebattle/DynamicAdapterBuilder.cs
@@ -28,6 +28,11 @@ public class DynamicAdapterCompiler
         using var ms = new MemoryStream();
         var result = compilation.Emit(ms);
 
+        if (!result.Success)
+        {
+            throw new InvalidOperationException("Compilation failed");
+        }
+
         ms.Seek(0, SeekOrigin.Begin);
         return Assembly.Load(ms.ToArray());
     }

--- a/spacebattle/DynamicAdapterBuilder.cs
+++ b/spacebattle/DynamicAdapterBuilder.cs
@@ -1,5 +1,4 @@
 ﻿namespace SpaceBattle;
-using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Reflection;
@@ -28,11 +27,6 @@ public class DynamicAdapterCompiler
 
         using var ms = new MemoryStream();
         var result = compilation.Emit(ms);
-
-        if (!result.Success)
-        {
-            throw new InvalidOperationException("Compilation failed");
-        }
 
         ms.Seek(0, SeekOrigin.Begin);
         return Assembly.Load(ms.ToArray());

--- a/spacebattle/IStrategy.cs
+++ b/spacebattle/IStrategy.cs
@@ -1,0 +1,7 @@
+﻿namespace SpaceBattle
+{
+    public interface IStrategy
+    {
+        public object Strategy(params object[] args);
+    }
+}

--- a/spacebattle/spacebattle.csproj
+++ b/spacebattle/spacebattle.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="CoreWCF.WebHttp" Version="1.5.2" />
     <PackageReference Include="json.Net" Version="1.0.33" />
     <PackageReference Include="Microsoft.Build" Version="17.3.1" />
+    <PackageReference Include="Microsoft.CodeAnalysis" Version="4.6.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="MinimalHelpers.Routing" Version="2.0.3" />
   </ItemGroup>

--- a/spacebattletests/StepDefinitions/AdapterGeneratorTests.cs
+++ b/spacebattletests/StepDefinitions/AdapterGeneratorTests.cs
@@ -18,7 +18,7 @@ public class AdapterGeneratorTests
     public void AdapterCodeGeneratorTest_1()
     {
 
-        var moveStartableAdapterCode =
+        var adapterCodeForStartable =
        @"class MoveStartableAdapter : IMoveStartable {
         Object target;
         public MoveStartableAdapter(Object target) => this.target = target; 
@@ -30,7 +30,7 @@ public class AdapterGeneratorTests
         }
     }";
 
-        var movableAdapterCode =
+        var adapterCodeForMovable =
         @"class MovableAdapter : IMovable {
         Vector target;
         public MovableAdapter(Vector target) => this.target = target; 
@@ -43,7 +43,7 @@ public class AdapterGeneratorTests
         }
     }";
 
-        Assert.Equal(moveStartableAdapterCode, IoC.Resolve<string>("Game.Reflection.GenerateAdapterCode", typeof(IMoveStartable), typeof(object)));
-        Assert.Equal(movableAdapterCode, IoC.Resolve<string>("Game.Reflection.GenerateAdapterCode", typeof(IMovable), typeof(Vector)));
+        Assert.Equal(adapterCodeForStartable, IoC.Resolve<string>("Game.Reflection.GenerateAdapterCode", typeof(IMoveStartable), typeof(object)));
+        Assert.Equal(adapterCodeForMovable, IoC.Resolve<string>("Game.Reflection.GenerateAdapterCode", typeof(IMovable), typeof(Vector)));
     }
 }

--- a/spacebattletests/StepDefinitions/AdapterGeneratorTests.cs
+++ b/spacebattletests/StepDefinitions/AdapterGeneratorTests.cs
@@ -1,0 +1,49 @@
+﻿namespace spacebattletests;
+using Hwdtech;
+using Hwdtech.Ioc;
+using spacebattle;
+using Xunit;
+
+public class AdapterGeneratorTests
+{
+    public AdapterGeneratorTests()
+    {
+        new InitScopeBasedIoCImplementationCommand().Execute();
+        IoC.Resolve<Hwdtech.ICommand>("Scopes.Current.Set", IoC.Resolve<object>("Scopes.New", IoC.Resolve<object>("Scopes.Root"))).Execute();
+
+        IoC.Resolve<Hwdtech.ICommand>("IoC.Register", "Game.Reflection.GenerateAdapterCode", (object[] args) => new AdapterCodeGeneratorStrategy().Strategy(args)).Execute();
+    }
+
+    [Fact]
+    public void AdapterCodeGeneratorTest_1()
+    {
+
+        var moveStartableAdapterCode =
+       @"class MoveStartableAdapter : IMoveStartable {
+        Object target;
+        public MoveStartableAdapter(Object target) => this.target = target; 
+        public IUObject Order {
+               get { return IoC.Resolve<IUObject>(""Game.Order.Get"", target); }
+        }
+        public Dictionary<String, Object> PropertiesOfOrder {
+               get { return IoC.Resolve<Dictionary<String, Object>>(""Game.PropertiesOfOrder.Get"", target); }
+        }
+    }";
+
+        var movableAdapterCode =
+        @"class MovableAdapter : IMovable {
+        Vector target;
+        public MovableAdapter(Vector target) => this.target = target; 
+        public Vector Position {
+               get { return IoC.Resolve<Vector>(""Game.Position.Get"", target); }
+               set { IoC.Resolve<_ICommand.ICommand>(""Game.Position.Set"", target, value).Execute(); }
+        }
+        public Vector Velocity {
+               get { return IoC.Resolve<Vector>(""Game.Velocity.Get"", target); }
+        }
+    }";
+
+        Assert.Equal(moveStartableAdapterCode, IoC.Resolve<string>("Game.Reflection.GenerateAdapterCode", typeof(IMoveStartable), typeof(object)));
+        Assert.Equal(movableAdapterCode, IoC.Resolve<string>("Game.Reflection.GenerateAdapterCode", typeof(IMovable), typeof(Vector)));
+    }
+}

--- a/spacebattletests/StepDefinitions/DynamicAdapterCompilerTests.cs
+++ b/spacebattletests/StepDefinitions/DynamicAdapterCompilerTests.cs
@@ -21,4 +21,17 @@ public class DynamicAdapterCompilerTests
         var instance = Activator.CreateInstance(testType);
         Assert.IsAssignableFrom(testType, instance);
     }
+
+    [Fact]
+    public void EnsureDynamicCompilationFails()
+    {
+        var code = @"
+            public interface ITestInterface { void TestMethod(); }
+            public class TestClass : ITestInterface {
+
+            }";
+
+        Exception exception = Assert.Throws<InvalidOperationException>(() => DynamicAdapterCompiler.CompileCode(code));
+        Assert.Equal("Compilation failed", exception.Message);
+    }
 }

--- a/spacebattletests/StepDefinitions/DynamicAdapterCompilerTests.cs
+++ b/spacebattletests/StepDefinitions/DynamicAdapterCompilerTests.cs
@@ -15,11 +15,9 @@ public class DynamicAdapterCompilerTests
                 public void TestMethod() {}
             }";
 
-        var compiledAssembly = DynamicAdapterCompiler.CompileCode(code);
-        var testType = compiledAssembly.GetType("TestClass");
-        Assert.NotNull(testType);
-        var instance = Activator.CreateInstance(testType);
-        Assert.IsAssignableFrom(testType, instance);
+        var assemblyOutput = DynamicAdapterCompiler.CompileCode(code);
+        var retrievedType = assemblyOutput.GetType("TestClass");
+        Assert.NotNull(retrievedType);
     }
 
     [Fact]
@@ -31,7 +29,7 @@ public class DynamicAdapterCompilerTests
 
             }";
 
-        Exception exception = Assert.Throws<InvalidOperationException>(() => DynamicAdapterCompiler.CompileCode(code));
-        Assert.Equal("Compilation failed", exception.Message);
+        Exception capturedException = Assert.Throws<InvalidOperationException>(() => DynamicAdapterCompiler.CompileCode(code));
+        Assert.Equal("Compilation failed", capturedException.Message);
     }
 }

--- a/spacebattletests/StepDefinitions/DynamicAdapterCompilerTests.cs
+++ b/spacebattletests/StepDefinitions/DynamicAdapterCompilerTests.cs
@@ -1,0 +1,24 @@
+﻿namespace spacebattletests;
+using System;
+using SpaceBattle;
+using Xunit;
+
+public class DynamicAdapterCompilerTests
+{
+    [Fact]
+    public void EnsureDynamicCompilationSucceeds()
+    {
+        _ = new DynamicAdapterCompiler();
+        var code = @"
+            public interface ITestInterface { void TestMethod(); }
+            public class TestClass : ITestInterface {
+                public void TestMethod() {}
+            }";
+
+        var compiledAssembly = DynamicAdapterCompiler.CompileCode(code);
+        var testType = compiledAssembly.GetType("TestClass");
+        Assert.NotNull(testType);
+        var instance = Activator.CreateInstance(testType);
+        Assert.IsAssignableFrom(testType, instance);
+    }
+}


### PR DESCRIPTION
Ряд команд, реализующих поведение космического корабля и других игровых объектов, устроены следующим образом:

class SomeCommand: ICommand
{
	private CommandTarget target;

	public SomeCommand(CommandTarget target) => this.target = target;

	public void Execute()
	{
		// реализация команды, которая обращается к объекту target.
	}
} 

Часто получение объекта такой Команды выполняется с помощью следующего кода:

IoC.Resolve<ICommand>(“SomeCommand”, obj);

где obj - объект, для которого будет выполнена создаваемая Команда. При этом стратегия для разрешения зависимости определяется следующим образом.

IoC.Resolve<ICommand>(
“IoC.Register”,
“SomeCommand”,
(Func<object[], object>)(args) => {
	var adapter = IoC.Resolve<SomeCommandTarget>(
“Adapter for SomeCommandTarget”, 
args[0]
);

return new SomeCommand(adapter);
}
).Execute(); 

IoC.Resolve<ICommand>(
“IoC.Register”,
“Adapter for SomeCommandTarget”,
(Func<object[], object>)(args) => return new SomeCommandTargetAdapter(args[0])
}
).Execute(); 

Для разных команд этот код отличается только типами самой команды SomeCommand, SomeCommandTarget и необходимостью написания класса SomeCommandTargetAdapter.

Если бы не класс SomeCommandTargetAdapter, то можно было бы обобщить данную стратегию до одного класса и избавиться от необходимости дублирования данного кода. Если использовать кодогенерацию и рефлексию, то можно этот класс сгенерировать автоматически, используя лишь определение интерфейса SomeCommandTarget.

Компиляция кода адаптера и стратегия создания адаптера по интерфейсу.